### PR TITLE
Updating amlfs docs to use unit in example

### DIFF
--- a/examples/shared_storage/aks/README.md
+++ b/examples/shared_storage/aks/README.md
@@ -53,6 +53,6 @@ This is an example of 16TiB filesystem with 2GBps total throughput:
 ```bash
 helm install shared-storage ./amlfs-shared-storage \
   --set storage.amlfs.skuName="AMLFS-Durable-Premium-125" \
-  --set storage.size=16 \
+  --set storage.size=16Ti \
   --set pvc.name="shared-storage-pvc"
 ```


### PR DESCRIPTION
If 16 is used for the size it will just round up to minimum storage size