### PR TITLE
fix: remove 'v' prefix from KUEUE_VERSION

### DIFF
--- a/infrastructure_references/aks/scripts/deploy-aks.sh
+++ b/infrastructure_references/aks/scripts/deploy-aks.sh
@@ -531,7 +531,7 @@ function install_kueue() {
         --namespace kueue-system \
         kueue \
         oci://registry.k8s.io/kueue/charts/kueue \
-        --version="${KUEUE_VERSION}"
+        --version="${KUEUE_VERSION#v}"
 
     echo "✅ Kueue installed successfully."
 }


### PR DESCRIPTION
Strip the 'v' prefix from KUEUE_VERSION when installing Kueue via Helm to ensure compatibility with Helm chart versioning format which expects semantic version numbers without the 'v' prefix.