### PR TITLE
Explicitly set locale for tr to support BSD-based platforms (e.g. macOS)

### DIFF
--- a/infrastructure_references/aks/scripts/deploy-aks.sh
+++ b/infrastructure_references/aks/scripts/deploy-aks.sh
@@ -17,7 +17,7 @@ fi
 : "${CLUSTER_NAME:=ai-infra}"
 : "${USER_NAME:=azureuser}"
 : "${SYSTEM_POOL_VM_SIZE:=}"
-: "${GRAFANA_PASSWORD:=$(tr </dev/urandom -dc 'A-Za-z0-9!@#$%&*_-' | head -c 30)}"
+: "${GRAFANA_PASSWORD:=$(LC_ALL=C tr </dev/urandom -dc 'A-Za-z0-9!@#$%&*_-' | head -c 30)}"
 
 # Versions
 : "${GPU_OPERATOR_VERSION:=v25.3.2}"      # Latest version: https://github.com/NVIDIA/gpu-operator/releases


### PR DESCRIPTION
When running `deploy-aks.sh` on BSD-based platforms like macOS, the `tr` command used to generate a Grafana passward will output "tr: Illegal byte sequence" stderr, not produce output to stdout, and exit 0 essentially not generating a password because it is locale aware.

The fix is to explicilty set a local for the call `LC_ALL=C tr...` which has no effective impact on the output on other platforms.

```
$ tr </dev/urandom -dc 'A-Za-z0-9!@#$%&*_-' | head -c 30 
tr: Illegal byte sequence
$ echo $?
0
$ pw=$(tr </dev/urandom -dc 'A-Za-z0-9!@#$%&*_-' | head -c 30)
tr: Illegal byte sequence
$ echo $pw

$ LC_ALL=C tr </dev/urandom -dc 'A-Za-z0-9!@#$%&*_-' | head -c 30
ksg9Zup&@cw6*0u!L*&5q0WfJMI25X%
```