### PR TITLE
Update squash file creation instructions in README

### DIFF
--- a/examples/llm-foundry/slurm/README.md
+++ b/examples/llm-foundry/slurm/README.md
@@ -111,8 +111,11 @@ Published image: `ghcr.io/azure/ai-infrastructure-on-azure/llm-foundry:latest`
 To create a squash file from the published image:
 
 ```bash
-sudo enroot import -o llm-foundry-latest.sqsh docker://ghcr.io/azure/ai-infrastructure-on-azure/llm-foundry:latest
+sudo docker pull ghcr.io/azure/ai-infrastructure-on-azure/llm-foundry:latest
+sudo enroot import -o llm-foundry-latest.sqsh dockerd://ghcr.io/azure/ai-infrastructure-on-azure/llm-foundry:latest
 ```
+
+> Note: The commands above will pull locally first and create from the Docker local cache.
 
 ### Manual Build (Optional)
 


### PR DESCRIPTION
Updated instructions for creating a squash file from the published image to include a Docker pull command and change the import source to 'dockerd'.

This method is simpler as enroot will try Docker Hub by default unless you configure credentials for `ghcr.io`.