### PR TITLE
Add VNET Integration option to AKS deployment script

### DIFF
--- a/infrastructure_references/aks/README.md
+++ b/infrastructure_references/aks/README.md
@@ -48,11 +48,11 @@ export NODE_POOL_VM_SIZE=""
 # export RDMA_DEVICE_PLUGIN=""
 # export CREATE_DEDICATED_VNET="true"          # Set to false to use AKS-generated VNet
 # export VNET_NAME=""                           # Defaults to "${CLUSTER_NAME}-vnet"
-# export VNET_ADDRESS_SPACE="10.10.0.0/16"       # VNet CIDR
+# export VNET_ADDRESS_SPACE="10.16.0.0/12"       # VNet CIDR (higher /12 boundary)
 # export AKS_SUBNET_NAME="aks"                  # Subnet for AKS nodes
-# export AKS_SUBNET_PREFIX="10.10.0.0/21"        # AKS subnet CIDR
+# export AKS_SUBNET_PREFIX="10.16.0.0/16"        # AKS subnet CIDR (default /16)
 # export SERVICE_SUBNET_NAME="service"          # Additional service subnet
-# export SERVICE_SUBNET_PREFIX="10.10.8.0/24"    # Service subnet CIDR
+# export SERVICE_SUBNET_PREFIX="10.17.0.0/16"    # Service subnet CIDR (default /16)
 # export USE_EXISTING_SUBNET_ID=""             # If set, skip VNet creation and use this subnet id
 ```
 
@@ -103,7 +103,7 @@ The `deploy-aks.sh` script supports the following commands:
 CREATE_DEDICATED_VNET=false ./scripts/deploy-aks.sh deploy-aks
 
 # Customize address space and subnets
-VNET_ADDRESS_SPACE=10.20.0.0/16 AKS_SUBNET_PREFIX=10.20.0.0/21 SERVICE_SUBNET_PREFIX=10.20.8.0/24 ./scripts/deploy-aks.sh deploy-aks
+VNET_ADDRESS_SPACE=10.32.0.0/12 AKS_SUBNET_PREFIX=10.32.0.0/16 SERVICE_SUBNET_PREFIX=10.33.0.0/16 ./scripts/deploy-aks.sh deploy-aks
 
 # Install with custom parameters
 ./scripts/deploy-aks.sh deploy-aks --node-vm-size standard_ds4_v2

--- a/infrastructure_references/aks/scripts/deploy-aks.sh
+++ b/infrastructure_references/aks/scripts/deploy-aks.sh
@@ -22,11 +22,11 @@ fi
 # Virtual Network configuration (optional dedicated VNet for AKS)
 : "${CREATE_DEDICATED_VNET:=true}"  # Set to false to use AKS generated VNet (current behavior)
 : "${VNET_NAME:=${CLUSTER_NAME}-vnet}"                 # Name of the VNet to create/use
-: "${VNET_ADDRESS_SPACE:=10.10.0.0/16}"                 # CIDR for VNet address space
+: "${VNET_ADDRESS_SPACE:=10.16.0.0/12}"                 # CIDR for VNet address space (higher /12 boundary)
 : "${AKS_SUBNET_NAME:=aks}"                            # Subnet name for AKS nodes
-: "${AKS_SUBNET_PREFIX:=10.10.0.0/21}"                  # CIDR for AKS subnet (defaults to /21)
+: "${AKS_SUBNET_PREFIX:=10.16.0.0/16}"                  # CIDR for AKS subnet (defaults to /16 within VNet)
 : "${SERVICE_SUBNET_NAME:=service}"                    # Subnet name for additional services
-: "${SERVICE_SUBNET_PREFIX:=10.10.8.0/24}"              # CIDR for service subnet (defaults to /24)
+: "${SERVICE_SUBNET_PREFIX:=10.17.0.0/16}"              # CIDR for service subnet (defaults to /16 within VNet)
 : "${USE_EXISTING_SUBNET_ID:=}"                        # If set, use this subnet id directly and skip VNet creation
 
 # Versions
@@ -673,11 +673,11 @@ function print_usage() {
     echo "  CREATE_DEDICATED_VNET    Create & use dedicated VNet/subnets for AKS (default: true)"
     echo "  USE_EXISTING_SUBNET_ID   Existing subnet resource ID to use directly (overrides CREATE_DEDICATED_VNET)"
     echo "  VNET_NAME                Name of VNet when CREATE_DEDICATED_VNET=true (default: \"${CLUSTER_NAME}-vnet\")"
-    echo "  VNET_ADDRESS_SPACE       CIDR for VNet address space (default: 10.10.0.0/16)"
+    echo "  VNET_ADDRESS_SPACE       CIDR for VNet address space (default: 10.16.0.0/12)"
     echo "  AKS_SUBNET_NAME          Name of AKS subnet (default: aks)"
-    echo "  AKS_SUBNET_PREFIX        CIDR for AKS subnet (default: 10.10.0.0/21)"
+    echo "  AKS_SUBNET_PREFIX        CIDR for AKS subnet (default: 10.16.0.0/16)"
     echo "  SERVICE_SUBNET_NAME      Name of service subnet (default: service)"
-    echo "  SERVICE_SUBNET_PREFIX    CIDR for service subnet (default: 10.10.8.0/24)"
+    echo "  SERVICE_SUBNET_PREFIX    CIDR for service subnet (default: 10.17.0.0/16)"
     echo ""
     echo "RDMA Device Plugin Options:"
     echo "  sriov-device-plugin      Uses SR-IOV device plugin (resource: rdma/ib)"


### PR DESCRIPTION
This pull request introduces support for dedicated Virtual Network (VNet) configuration when deploying Azure Kubernetes Service (AKS) clusters, providing users more control over networking resources. The changes add environment variables and logic to create, reuse, or bypass dedicated VNets and subnets, update documentation with usage examples, and bump default operator versions.

**Networking and VNet configuration:**

* Added environment variables (`CREATE_DEDICATED_VNET`, `VNET_NAME`, `VNET_ADDRESS_SPACE`, `AKS_SUBNET_NAME`, `AKS_SUBNET_PREFIX`, `SERVICE_SUBNET_NAME`, `SERVICE_SUBNET_PREFIX`, `USE_EXISTING_SUBNET_ID`) to allow creation, customization, or reuse of a dedicated VNet and subnets for AKS deployment in `README.md` and `deploy-aks.sh`. [[1]](diffhunk://#diff-f08c2c83e0b4b35bd05aadb380d29df45fe1354dc41acd273307eb1348b94a57L30-R30) [[2]](diffhunk://#diff-f08c2c83e0b4b35bd05aadb380d29df45fe1354dc41acd273307eb1348b94a57R49-R59) [[3]](diffhunk://#diff-8680982f64ccadf3d5eea1b575efccf212f877dd41100d31ffd65f8b862d987bR22-R31)
* Implemented the `ensure_vnet_and_subnets` function in `deploy-aks.sh` to idempotently create or reuse the VNet and subnets, and export the subnet ID for AKS cluster creation.
* Updated AKS deployment logic to select networking strategy based on the new environment variables, supporting use of existing subnets or disabling dedicated VNet creation. [[1]](diffhunk://#diff-8680982f64ccadf3d5eea1b575efccf212f877dd41100d31ffd65f8b862d987bR136-R146) [[2]](diffhunk://#diff-8680982f64ccadf3d5eea1b575efccf212f877dd41100d31ffd65f8b862d987bR163-R167)
* Expanded documentation with configuration examples for dedicated VNet usage, customization, and bypassing VNet creation, including new usage instructions and environment variable descriptions. [[1]](diffhunk://#diff-f08c2c83e0b4b35bd05aadb380d29df45fe1354dc41acd273307eb1348b94a57R101-R107) [[2]](diffhunk://#diff-f08c2c83e0b4b35bd05aadb380d29df45fe1354dc41acd273307eb1348b94a57R230-R255) [[3]](diffhunk://#diff-8680982f64ccadf3d5eea1b575efccf212f877dd41100d31ffd65f8b862d987bR673-R680)

**Operator version updates:**

* Updated default versions for GPU Operator (`v25.3.4`) and Network Operator (`v25.7.0`) in both documentation and script defaults. [[1]](diffhunk://#diff-f08c2c83e0b4b35bd05aadb380d29df45fe1354dc41acd273307eb1348b94a57L119-R135) [[2]](diffhunk://#diff-8680982f64ccadf3d5eea1b575efccf212f877dd41100d31ffd65f8b862d987bR22-R31) [[3]](diffhunk://#diff-8680982f64ccadf3d5eea1b575efccf212f877dd41100d31ffd65f8b862d987bL581-R662)

These changes make AKS deployment more flexible and robust, especially for users with advanced networking requirements.