### PR TITLE
InferenceX AKS: autotuner cache + suite driver + blob-cache fix

### DIFF
--- a/examples/inferenceX/aks/README.md
+++ b/examples/inferenceX/aks/README.md
@@ -132,6 +132,46 @@ sequenceDiagram
 
 Workers mount the same hostPath read-only once the distribute job completes; subsequent recipe swaps reuse the cached model with no re-download. The blob cache is optional (`modelDistribution.blobCache.enabled=false` skips it and always uses HuggingFace) but makes cold starts ~10× faster for large clusters.
 
+### 3.1 TRT-LLM autotuner cache
+
+Separate from the model cache, TRT-LLM runs an **autotuner** on every worker startup to pick optimal kernels for the current shapes. On GB300 with DeepSeek-R1 this takes **~2.5 min** per pod start — the same cost Slurm `srt-slurm` pays today (we checked; it does not cache either). TRT-LLM supports `TLLM_AUTOTUNER_CACHE_PATH`, which reads/writes per-rank JSON files (`{base}.rank{N}.json`) so a warm restart is ~1s instead of 2.5 min.
+
+Enabling that in a Kubernetes chart hits two design problems:
+
+1. **Model collision.** A single flat cache directory would mix entries from different models. Autotuner keys are shape-based (arch × dtype × parallelism), so a stale entry from a previous model could be silently selected.
+2. **Rank ↔ node shuffle.** Cache files are keyed by MPI rank, but Kubernetes re-shuffles which node gets which rank on every redeploy. A hostPath cache on node A might hold `rank3.json` from run 1, then rank 3 lands on node B for run 2 and the autotune re-runs from scratch.
+
+The chart solves both in ~15 lines of `worker-entrypoint.sh`:
+
+```mermaid
+flowchart TB
+    start["Worker pod starts<br/>TLLM_AUTOTUNER_CACHE_PATH=/autotuner-cache/inferencex.cache"] --> scope
+    scope["Rewrite path to include sanitized model name<br/>→ /autotuner-cache/deepseek-r1-0528-fp4-v2/inferencex.cache"] --> check
+    check{"rank{MY_RANK}.json<br/>exists in dir?"}
+    check -- yes --> hit["Use it — warm start<br/>~1s autotune"]
+    check -- no --> donor{"Any other<br/>rank*.json<br/>in dir?"}
+    donor -- yes --> seed["cp donor → rank{MY_RANK}.json<br/>warm start"]
+    donor -- no --> cold["Tune from scratch<br/>~2.5 min, then write cache"]
+    hit --> run["exec trtllm-llmapi-launch"]
+    seed --> run
+    cold --> run
+```
+
+**Why rank-agnostic seeding is safe.** The autotuner key is a shape tuple (model arch, dtype, tensor-parallel degree, batch/seq shapes); MPI rank is not part of the key. All ranks in a given MPI world tune identical kernels. Copying a sibling-rank file is therefore equivalent to using our own — no kernel-selection drift.
+
+**Why per-model scoping matters.** Without it, the above seed would happily copy a DeepSeek cache file over a Llama rank file, producing semantically wrong kernel choices. The sanitized-model-name subdirectory (`tr '/: ' '___'` on `model.name`) gives every model its own namespace; switching models gets a clean slate, and wiping `/mnt/nvme/autotuner-cache/<model>/` on every node forces a re-tune for that model only.
+
+**Alternatives considered and rejected.**
+- **Node pinning** (`nodePinning.enabled: true`) — would stabilize rank→node mapping and make the cache trivially correct, but sacrifices scheduler flexibility and breaks on cordoned nodes / multiple concurrent jobs.
+- **Shared cache on NFS/PVC** — globally consistent, but adds a ReadWriteMany volume dependency on every pod startup and is slower than hostPath on first read.
+- **Accept partial hits, run suite 3–4× until cache converges naturally** — works, but wastes compute on every fresh cluster.
+
+The rank-agnostic hostPath approach gives the full speedup (warm start ≈ 1s) with no scheduler impact and no new infra.
+
+**Disabling.** Set `autotunerCache.enabled: false` in values. The hostPath volume, env var, and `mpirun -x` forwarding all drop out; the bash block in `worker-entrypoint.sh` short-circuits because `TLLM_AUTOTUNER_CACHE_PATH` is unset. TRT-LLM then re-tunes on every pod start (~2.5 min penalty).
+
+Tunables live under `autotunerCache:` in `values-gb300-base.yaml`. Measured impact on GB300 is in [gb300-benchmark-walkthrough.md §Autotuner cache](gb300-benchmark-walkthrough.md#autotuner-cache).
+
 ---
 
 ## 4. Prerequisites

--- a/examples/inferenceX/aks/README.md
+++ b/examples/inferenceX/aks/README.md
@@ -170,6 +170,11 @@ The rank-agnostic hostPath approach gives the full speedup (warm start ≈ 1s) w
 
 **Disabling.** Set `autotunerCache.enabled: false` in values. The hostPath volume, env var, and `mpirun -x` forwarding all drop out; the bash block in `worker-entrypoint.sh` short-circuits because `TLLM_AUTOTUNER_CACHE_PATH` is unset. TRT-LLM then re-tunes on every pod start (~2.5 min penalty).
 
+**Reuse scope — same recipe only.** TRT-LLM's autotuner key is the *bucketed input shape* (see `tensorrt_llm/_torch/autotuner.py:442-461`); concurrency is not literally in the key, but different concurrencies map to different shape buckets and therefore different cache entries. Two consequences:
+
+1. The cache is **safe to reuse across pod restarts of the same recipe** (rolling updates, evictions, suite re-runs against the same `values-gb300-*.yaml`). This is the supported path.
+2. The cache is **NOT safe to reuse across recipes** that change concurrency or topology. Mixing recipes against the same long-lived deployment via `-s` has been observed to inflate prefill TTFT 2–4× because runtime traffic hits shape buckets that warmup never primed (cache miss → in-line autotune on the first request of each new bucket, and TRT-LLM only persists warmup-tuned shapes to disk — runtime tunes are in-memory only). `run-suite.sh` calls `-t` between every recipe to ensure each starts with a deploy whose warmup matches the workload.
+
 Tunables live under `autotunerCache:` in `values-gb300-base.yaml`. Measured impact on GB300 is in [gb300-benchmark-walkthrough.md §Autotuner cache](gb300-benchmark-walkthrough.md#autotuner-cache).
 
 ---

--- a/examples/inferenceX/aks/README.md
+++ b/examples/inferenceX/aks/README.md
@@ -349,6 +349,12 @@ results/conc-24_20260417T143022Z/
 
 The `pod-placement.tsv` and `timings.txt` files are used for Grafana correlation when generating plots after the run.
 
+### Teardown between recipes (`-t`)
+
+`-t` does a **full chart teardown**: workloads (MPIJobs, ComputeDomain, ResourceClaims) **and** chart infra (frontend Deployment, etcd/NATS StatefulSets, ConfigMaps, Services, Secrets — selected via `app.kubernetes.io/instance=inferencex`). It is required between recipes that change topology, and recommended any time you've redeployed several recipes onto a long-lived frontend.
+
+The reason is **stale Dynamo router state**. Each `helm template | kubectl apply` adds new prefill/decode workers to the router's worker registry but never removes the previous ones. A frontend that has served many redeploys throttles prefill dispatch through a saturated worker list — TTFT inflates from ~1.8 s to ~7 s on conc-24 even though TPOT is unchanged. `run-suite.sh` uses `-t` between every topology group for this reason.
+
 ### Pass criteria
 
 A run `PASS`es if AKS per-GPU throughput lands within ±5% of `inferencex_tput_per_gpu`. The runner prints the verdict and writes it to `summary.txt`.

--- a/examples/inferenceX/aks/README.md
+++ b/examples/inferenceX/aks/README.md
@@ -337,6 +337,9 @@ cd examples/inferenceX/aks
 # Re-run benchmark only (helm release already running the right values)
 ./run-test.sh tests/trtllm/gb300-fp4/8k1k/mtp/conc-666.yaml -s
 
+# Disable the TRT-LLM autotuner cache for this deploy (cold ~2.5 min autotune)
+./run-test.sh tests/trtllm/gb300-fp4/8k1k/mtp/conc-24.yaml -t -A
+
 # Dry run
 ./run-test.sh tests/trtllm/gb300-fp4/8k1k/mtp/conc-5.yaml -d
 ```
@@ -358,7 +361,9 @@ The `pod-placement.tsv` and `timings.txt` files are used for Grafana correlation
 
 `-t` does a **full chart teardown**: workloads (MPIJobs, ComputeDomain, ResourceClaims) **and** chart infra (frontend Deployment, etcd/NATS StatefulSets, ConfigMaps, Services, Secrets — selected via `app.kubernetes.io/instance=inferencex`). It is required between recipes that change topology, and recommended any time you've redeployed several recipes onto a long-lived frontend.
 
-The reason is **stale Dynamo router state**. Each `helm template | kubectl apply` adds new prefill/decode workers to the router's worker registry but never removes the previous ones. A frontend that has served many redeploys throttles prefill dispatch through a saturated worker list — TTFT inflates from ~1.8 s to ~7 s on conc-24 even though TPOT is unchanged. `run-suite.sh` uses `-t` between every topology group for this reason.
+The reason is **stale Dynamo router state**. Each `helm template | kubectl apply` adds new prefill/decode workers to the router's worker registry but never removes the previous ones. A frontend that has served many redeploys throttles prefill dispatch through a saturated worker list — TTFT inflates from ~1.8 s to ~7 s on conc-24 even though TPOT is unchanged. Combined with the autotuner shape-bucket issue described in [§3.1](#31-trt-llm-autotuner-cache), `run-suite.sh` uses `-t` between **every recipe** (not just between topology groups).
+
+`-t` deletes chart resources only; it leaves `/mnt/nvme/autotuner-cache/<model>/` intact on every node. A re-deploy of the same recipe after `-t` therefore still gets a warm autotune (~1 s) on the next start.
 
 ### Pass criteria
 

--- a/examples/inferenceX/aks/README.md
+++ b/examples/inferenceX/aks/README.md
@@ -162,6 +162,7 @@ flowchart TB
 **Why per-model scoping matters.** Without it, the above seed would happily copy a DeepSeek cache file over a Llama rank file, producing semantically wrong kernel choices. The sanitized-model-name subdirectory (`tr '/: ' '___'` on `model.name`) gives every model its own namespace; switching models gets a clean slate, and wiping `/mnt/nvme/autotuner-cache/<model>/` on every node forces a re-tune for that model only.
 
 **Alternatives considered and rejected.**
+
 - **Node pinning** (`nodePinning.enabled: true`) — would stabilize rank→node mapping and make the cache trivially correct, but sacrifices scheduler flexibility and breaks on cordoned nodes / multiple concurrent jobs.
 - **Shared cache on NFS/PVC** — globally consistent, but adds a ReadWriteMany volume dependency on every pod startup and is slower than hostPath on first read.
 - **Accept partial hits, run suite 3–4× until cache converges naturally** — works, but wastes compute on every fresh cluster.
@@ -170,7 +171,7 @@ The rank-agnostic hostPath approach gives the full speedup (warm start ≈ 1s) w
 
 **Disabling.** Set `autotunerCache.enabled: false` in values. The hostPath volume, env var, and `mpirun -x` forwarding all drop out; the bash block in `worker-entrypoint.sh` short-circuits because `TLLM_AUTOTUNER_CACHE_PATH` is unset. TRT-LLM then re-tunes on every pod start (~2.5 min penalty).
 
-**Reuse scope — same recipe only.** TRT-LLM's autotuner key is the *bucketed input shape* (see `tensorrt_llm/_torch/autotuner.py:442-461`); concurrency is not literally in the key, but different concurrencies map to different shape buckets and therefore different cache entries. Two consequences:
+**Reuse scope — same recipe only.** TRT-LLM's autotuner key is the _bucketed input shape_ (see `tensorrt_llm/_torch/autotuner.py:442-461`); concurrency is not literally in the key, but different concurrencies map to different shape buckets and therefore different cache entries. Two consequences:
 
 1. The cache is **safe to reuse across pod restarts of the same recipe** (rolling updates, evictions, suite re-runs against the same `values-gb300-*.yaml`). This is the supported path.
 2. The cache is **NOT safe to reuse across recipes** that change concurrency or topology. Mixing recipes against the same long-lived deployment via `-s` has been observed to inflate prefill TTFT 2–4× because runtime traffic hits shape buckets that warmup never primed (cache miss → in-line autotune on the first request of each new bucket, and TRT-LLM only persists warmup-tuned shapes to disk — runtime tunes are in-memory only). `run-suite.sh` calls `-t` between every recipe to ensure each starts with a deploy whose warmup matches the workload.

--- a/examples/inferenceX/aks/gb300-benchmark-walkthrough.md
+++ b/examples/inferenceX/aks/gb300-benchmark-walkthrough.md
@@ -155,6 +155,79 @@ The cache hit shaves ~6.5 min off every redeploy. The model only needs to land o
 
 ---
 
+## Autotuner cache
+
+TRT-LLM runs a ~2 min kernel autotuner on every worker startup. The chart persists autotuner state to `/mnt/nvme/autotuner-cache/<sanitized-model>/` on each node and seeds each rank's expected filename from any sibling-rank file left behind by a previous run (design in [README §3.1](README.md#31-trt-llm-autotuner-cache)).
+
+Measured on conc-5 (`values-gb300-ctx1-gen4.yaml`, 34 GPUs, DeepSeek-R1 FP4, 18-node `paul-gb300` cluster, two clean runs back-to-back):
+
+| Run | State | Autotune phase | Worker startup | Total wall-clock | Throughput |
+|---|---|---:|---:|---:|---:|
+| 1 (`conc-5_20260421T151222Z`) | Cold (cache wiped) | **2 min 19 s** | 8 min 57 s | 11 min 33 s | 109.8% of ref |
+| 2 (`conc-5_20260421T152610Z`) | Warm (seed + redeploy) | **1 s** | 5 min 12 s | 6 min 45 s | 109.8% of ref |
+| Δ | | **−138×** | −3 min 45 s | **−4 min 48 s** | identical |
+
+Throughput identical between cold and warm runs → no kernel-quality regression from sibling-rank seeding (the key correctness check; the autotuner key is shape-based and rank-independent, so cloning a sibling-rank file is equivalent to running tuning ourselves).
+
+**Cache decisions across all 34 GPUs in Run 2** (rank-agnostic seed in action — Kubernetes shuffled rank→node assignments between runs, so most ranks needed seeding):
+
+| MPIJob | Cache hits | Seeded from sibling | Empty (must tune) |
+|---|---:|---:|---:|
+| decode-0 | 0 | 8 | 0 |
+| decode-1 | 0 | 4 | 4 |
+| decode-2 | 4 | 0 | 4 |
+| decode-3 | 8 | 0 | 0 |
+| prefill-0 | 2 | 0 | 0 |
+| **Total** | **14** | **12** | **8** |
+
+Of 34 GPUs: 14 found their own cache file, 12 were seeded from a sibling rank on the same node (~1s `cp`), 8 landed on nodes that hadn't run any worker in Run 1 and so had to tune cold. Subsequent runs converge toward 100% hit/seed as the cache fills out across the fleet.
+
+Sample log lines from `inferencex-decode-0-launcher` showing the seed firing:
+
+```
+[rank=0] Autotuner cache path: /autotuner-cache/deepseek-r1-0528-fp4-v2/inferencex
+[rank=0] Autotuner cache seeded: inferencex.rank4.json -> inferencex.rank0.json
+[rank=3] Autotuner cache seeded: inferencex.rank4.json -> inferencex.rank3.json
+```
+
+Inspect cache on a node:
+
+```bash
+NODE=$(kubectl get nodes -l agentpool=gb300 -o jsonpath='{.items[0].metadata.name}')
+kubectl debug node/$NODE -it --image=busybox -- \
+  sh -c 'ls -la /host/mnt/nvme/autotuner-cache/*/ 2>/dev/null'
+```
+
+Force a full re-tune (e.g. after a TRT-LLM runtime image upgrade):
+
+```bash
+kubectl apply -f - <<'EOF'
+apiVersion: apps/v1
+kind: DaemonSet
+metadata: { name: clear-autotuner, namespace: default }
+spec:
+  selector: { matchLabels: { app: clear-autotuner } }
+  template:
+    metadata: { labels: { app: clear-autotuner } }
+    spec:
+      nodeSelector: { agentpool: gb300 }
+      tolerations:
+      - { key: nvidia.com/gpu, operator: Exists, effect: NoSchedule }
+      - { key: sku, operator: Equal, value: gpu, effect: NoSchedule }
+      containers:
+      - name: wipe
+        image: busybox
+        command: ["sh","-c","rm -rf /host/mnt/nvme/autotuner-cache/* && echo done on $(hostname) && sleep 3600"]
+        securityContext: { privileged: true }
+        volumeMounts: [{ name: host, mountPath: /host }]
+      volumes: [{ name: host, hostPath: { path: / } }]
+EOF
+kubectl rollout status ds/clear-autotuner --timeout=2m
+kubectl delete ds clear-autotuner
+```
+
+---
+
 ## Pod → node placement (Grafana correlation tables)
 
 All node names are the AKS VMSS instance names; correlate with Azure Monitor / Prometheus by `node` label or `kubernetes.io/hostname`. Static singletons are placed once at namespace creation and persist across all recipes:

--- a/examples/inferenceX/aks/gb300-benchmark-walkthrough.md
+++ b/examples/inferenceX/aks/gb300-benchmark-walkthrough.md
@@ -169,6 +169,18 @@ Measured on conc-5 (`values-gb300-ctx1-gen4.yaml`, 34 GPUs, DeepSeek-R1 FP4, 18-
 
 Throughput identical between cold and warm runs → no kernel-quality regression from sibling-rank seeding (the key correctness check; the autotuner key is shape-based and rank-independent, so cloning a sibling-rank file is equivalent to running tuning ourselves).
 
+**Re-validation on a different recipe** (conc-33, `values-gb300-ctx1-gen3.yaml`, 26 GPUs, two clean back-to-back runs on the 18-node cluster, `2026-04-22T12:46Z` cold and `2026-04-22T12:58Z` warm):
+
+| Run | State | `WAIT_READY → MODELS_POPULATED` | `WAIT_READY → WORKERS_READY` | Throughput |
+|---|---|---:|---:|---:|
+| Cold (cache wiped fleet-wide) | first deploy | 6 min 11 s | 8 min 58 s | 1607.2 tok/s/GPU (99.7%) |
+| Warm (cache from cold run on `/mnt/nvme`) | second deploy | 5 min 22 s | 8 min 9 s | 1606.9 tok/s/GPU (99.7%) |
+| Δ | | **−49 s (−13%)** | **−49 s (−9%)** | identical |
+
+Top-level wall-clock savings on a single warm run (49 s) are smaller than the autotune sub-phase delta (~2 min) because parallel costs — pod scheduling, model load from local NVMe, NCCL init, Dynamo router registration — overlap with the autotune work and dominate the critical path. The throughput-identical PASS in both runs is the important signal: the cache reload produces the same kernels and the same end-state performance.
+
+**Caveat — cross-recipe reuse is unsafe.** The cache is shape-bucketed (see [README §3.1](README.md#31-trt-llm-autotuner-cache)); reusing it across recipes that differ in concurrency or topology has been observed to inflate TTFT 2–4× on a deployment shared via `-s` (skip-deploy). Always teardown (`-t`) between recipes that change concurrency. `run-suite.sh` does this automatically.
+
 **Cache decisions across all 34 GPUs in Run 2** (rank-agnostic seed in action — Kubernetes shuffled rank→node assignments between runs, so most ranks needed seeding):
 
 | MPIJob | Cache hits | Seeded from sibling | Empty (must tune) |

--- a/examples/inferenceX/aks/gb300-benchmark-walkthrough.md
+++ b/examples/inferenceX/aks/gb300-benchmark-walkthrough.md
@@ -161,21 +161,21 @@ TRT-LLM runs a ~2 min kernel autotuner on every worker startup. The chart persis
 
 Measured on conc-5 (`values-gb300-ctx1-gen4.yaml`, 34 GPUs, DeepSeek-R1 FP4, 18-node `paul-gb300` cluster, two clean runs back-to-back):
 
-| Run | State | Autotune phase | Worker startup | Total wall-clock | Throughput |
-|---|---|---:|---:|---:|---:|
-| 1 (`conc-5_20260421T151222Z`) | Cold (cache wiped) | **2 min 19 s** | 8 min 57 s | 11 min 33 s | 109.8% of ref |
-| 2 (`conc-5_20260421T152610Z`) | Warm (seed + redeploy) | **1 s** | 5 min 12 s | 6 min 45 s | 109.8% of ref |
-| Δ | | **−138×** | −3 min 45 s | **−4 min 48 s** | identical |
+| Run                           | State                  | Autotune phase | Worker startup | Total wall-clock |    Throughput |
+| ----------------------------- | ---------------------- | -------------: | -------------: | ---------------: | ------------: |
+| 1 (`conc-5_20260421T151222Z`) | Cold (cache wiped)     | **2 min 19 s** |     8 min 57 s |      11 min 33 s | 109.8% of ref |
+| 2 (`conc-5_20260421T152610Z`) | Warm (seed + redeploy) |        **1 s** |     5 min 12 s |       6 min 45 s | 109.8% of ref |
+| Δ                             |                        |      **−138×** |    −3 min 45 s |  **−4 min 48 s** |     identical |
 
 Throughput identical between cold and warm runs → no kernel-quality regression from sibling-rank seeding (the key correctness check; the autotuner key is shape-based and rank-independent, so cloning a sibling-rank file is equivalent to running tuning ourselves).
 
 **Re-validation on a different recipe** (conc-33, `values-gb300-ctx1-gen3.yaml`, 26 GPUs, two clean back-to-back runs on the 18-node cluster, `2026-04-22T12:46Z` cold and `2026-04-22T12:58Z` warm):
 
-| Run | State | `WAIT_READY → MODELS_POPULATED` | `WAIT_READY → WORKERS_READY` | Throughput |
-|---|---|---:|---:|---:|
-| Cold (cache wiped fleet-wide) | first deploy | 6 min 11 s | 8 min 58 s | 1607.2 tok/s/GPU (99.7%) |
-| Warm (cache from cold run on `/mnt/nvme`) | second deploy | 5 min 22 s | 8 min 9 s | 1606.9 tok/s/GPU (99.7%) |
-| Δ | | **−49 s (−13%)** | **−49 s (−9%)** | identical |
+| Run                                       | State         | `WAIT_READY → MODELS_POPULATED` | `WAIT_READY → WORKERS_READY` |               Throughput |
+| ----------------------------------------- | ------------- | ------------------------------: | ---------------------------: | -----------------------: |
+| Cold (cache wiped fleet-wide)             | first deploy  |                      6 min 11 s |                   8 min 58 s | 1607.2 tok/s/GPU (99.7%) |
+| Warm (cache from cold run on `/mnt/nvme`) | second deploy |                      5 min 22 s |                    8 min 9 s | 1606.9 tok/s/GPU (99.7%) |
+| Δ                                         |               |                **−49 s (−13%)** |              **−49 s (−9%)** |                identical |
 
 Top-level wall-clock savings on a single warm run (49 s) are smaller than the autotune sub-phase delta (~2 min) because parallel costs — pod scheduling, model load from local NVMe, NCCL init, Dynamo router registration — overlap with the autotune work and dominate the critical path. The throughput-identical PASS in both runs is the important signal: the cache reload produces the same kernels and the same end-state performance.
 
@@ -183,14 +183,14 @@ Top-level wall-clock savings on a single warm run (49 s) are smaller than the au
 
 **Cache decisions across all 34 GPUs in Run 2** (rank-agnostic seed in action — Kubernetes shuffled rank→node assignments between runs, so most ranks needed seeding):
 
-| MPIJob | Cache hits | Seeded from sibling | Empty (must tune) |
-|---|---:|---:|---:|
-| decode-0 | 0 | 8 | 0 |
-| decode-1 | 0 | 4 | 4 |
-| decode-2 | 4 | 0 | 4 |
-| decode-3 | 8 | 0 | 0 |
-| prefill-0 | 2 | 0 | 0 |
-| **Total** | **14** | **12** | **8** |
+| MPIJob    | Cache hits | Seeded from sibling | Empty (must tune) |
+| --------- | ---------: | ------------------: | ----------------: |
+| decode-0  |          0 |                   8 |                 0 |
+| decode-1  |          0 |                   4 |                 4 |
+| decode-2  |          4 |                   0 |                 4 |
+| decode-3  |          8 |                   0 |                 0 |
+| prefill-0 |          2 |                   0 |                 0 |
+| **Total** |     **14** |              **12** |             **8** |
 
 Of 34 GPUs: 14 found their own cache file, 12 were seeded from a sibling rank on the same node (~1s `cp`), 8 landed on nodes that hadn't run any worker in Run 1 and so had to tune cold. Subsequent runs converge toward 100% hit/seed as the cache fills out across the fleet.
 

--- a/examples/inferenceX/aks/helm/inferencex/templates/_helpers.tpl
+++ b/examples/inferenceX/aks/helm/inferencex/templates/_helpers.tpl
@@ -160,6 +160,10 @@ containers:
     mountPath: /etc/ssh
   - name: sshd-run
     mountPath: /run/sshd
+  {{- if .root.Values.autotunerCache.enabled }}
+  - name: autotuner-cache
+    mountPath: {{ .root.Values.autotunerCache.mountPath }}
+  {{- end }}
 {{- if .root.Values.dra.enabled }}
 resourceClaims:
 - name: {{ .root.Values.dra.claimTemplateName }}
@@ -193,6 +197,12 @@ volumes:
   emptyDir: {}
 - name: sshd-run
   emptyDir: {}
+{{- if .root.Values.autotunerCache.enabled }}
+- name: autotuner-cache
+  hostPath:
+    path: {{ .root.Values.autotunerCache.hostPath }}
+    type: DirectoryOrCreate
+{{- end }}
 {{- if .root.Values.model.hfTokenSecret }}
 - name: hf-token
   secret:
@@ -244,6 +254,10 @@ Expects root (top-level context) and role.
 {{- end }}
 {{- end }}
 {{- end }}
+{{- if .root.Values.autotunerCache.enabled }}
+- name: TLLM_AUTOTUNER_CACHE_PATH
+  value: "{{ .root.Values.autotunerCache.mountPath }}/{{ .root.Values.autotunerCache.baseName }}"
+{{- end }}
 {{- end }}
 
 {{/*
@@ -273,5 +287,8 @@ mpirun -x flags for forwarding env vars to workers.
 -x {{ $key }} \
 {{- end }}
 {{- end }}
+{{- end }}
+{{- if .root.Values.autotunerCache.enabled }}
+-x TLLM_AUTOTUNER_CACHE_PATH \
 {{- end }}
 {{- end }}

--- a/examples/inferenceX/aks/helm/inferencex/templates/configmap-scripts.yaml
+++ b/examples/inferenceX/aks/helm/inferencex/templates/configmap-scripts.yaml
@@ -116,9 +116,21 @@ data:
           install_azcopy
           azcopy_configure_msi
           echo "[rank=0] Checking blob cache at ${BLOB_URL}..."
-          if azcopy list "${BLOB_URL}" --log-level ERROR 2>/dev/null | grep -q "INFO:"; then
-            echo "[rank=0] Found in blob cache, downloading with azcopy..."
+          # Count actual blob entries. azcopy emits one "INFO: Authenticating to
+          # source using Azure AD" banner on every call (even for empty/nonexistent
+          # prefixes) plus one "<path>; Content Length: ..." line per real entry.
+          # Entry lines do NOT start with "INFO:" — gate on the " Content Length:"
+          # substring only, which is absent from the auth banner.
+          BLOB_COUNT=$(azcopy list "${BLOB_URL}" --log-level ERROR 2>/dev/null \
+                        | grep -cE 'Content Length:')
+          echo "[rank=0] Blob cache entries found: ${BLOB_COUNT}"
+          if [ "${BLOB_COUNT}" -gt 0 ]; then
+            T0=$(date -u +%s)
+            echo "[rank=0] BLOB_DOWNLOAD_START $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            echo "[rank=0] Downloading ${BLOB_COUNT} entries from blob cache..."
             azcopy copy "${BLOB_URL}/*" "$MODEL_DIR/" --recursive --log-level ERROR
+            T1=$(date -u +%s)
+            echo "[rank=0] BLOB_DOWNLOAD_END $(date -u +%Y-%m-%dT%H:%M:%SZ) elapsed=$((T1-T0))s"
             GOT_FROM_BLOB=true
           else
             echo "[rank=0] Not in blob cache"
@@ -132,6 +144,8 @@ data:
           if [ -n "$HF_TOKEN" ]; then
             export HF_TOKEN
           fi
+          HF_T0=$(date -u +%s)
+          echo "[rank=0] HF_DOWNLOAD_START $(date -u +%Y-%m-%dT%H:%M:%SZ)"
           for attempt in 1 2 3 4 5; do
             echo "[rank=0] Download attempt $attempt/5"
             if python3 -c "from huggingface_hub import snapshot_download; snapshot_download('${MODEL_HF_ID}', local_dir='${MODEL_DIR}')"; then
@@ -140,13 +154,22 @@ data:
             [ "$attempt" -eq 5 ] && { echo "[rank=0] All download attempts failed"; exit 1; }
             sleep 10
           done
+          HF_T1=$(date -u +%s)
+          echo "[rank=0] HF_DOWNLOAD_END $(date -u +%Y-%m-%dT%H:%M:%SZ) elapsed=$((HF_T1-HF_T0))s"
 
           if [ "$BLOB_ENABLED" = "true" ] && [ -n "$BLOB_ACCOUNT" ]; then
             install_azcopy
             azcopy_configure_msi
+            BU_T0=$(date -u +%s)
+            echo "[rank=0] BLOB_UPLOAD_START $(date -u +%Y-%m-%dT%H:%M:%SZ)"
             echo "[rank=0] Caching to blob storage..."
-            azcopy copy "$MODEL_DIR/*" "${BLOB_URL}/" --recursive --log-level ERROR || \
-              echo "[rank=0] WARNING: blob cache upload failed (non-fatal)"
+            if azcopy copy "$MODEL_DIR/*" "${BLOB_URL}/" --recursive --log-level ERROR; then
+              BU_T1=$(date -u +%s)
+              echo "[rank=0] BLOB_UPLOAD_END $(date -u +%Y-%m-%dT%H:%M:%SZ) elapsed=$((BU_T1-BU_T0))s"
+            else
+              BU_T1=$(date -u +%s)
+              echo "[rank=0] BLOB_UPLOAD_FAILED elapsed=$((BU_T1-BU_T0))s (non-fatal)"
+            fi
           fi
         fi
 

--- a/examples/inferenceX/aks/helm/inferencex/templates/configmap-scripts.yaml
+++ b/examples/inferenceX/aks/helm/inferencex/templates/configmap-scripts.yaml
@@ -32,6 +32,31 @@ data:
     LOCAL_RANK=${OMPI_COMM_WORLD_LOCAL_RANK:-0}
     WORLD_SIZE=${OMPI_COMM_WORLD_SIZE:-1}
 
+    # Autotuner cache: per-model scoping + rank-agnostic seeding. See README §3.1.
+    if [ -n "${TLLM_AUTOTUNER_CACHE_PATH:-}" ] && [ -n "${MODEL_NAME:-}" ]; then
+      _cache_root="$(dirname "$TLLM_AUTOTUNER_CACHE_PATH")"
+      _cache_base="$(basename "$TLLM_AUTOTUNER_CACHE_PATH")"
+      _model_slug="$(printf '%s' "$MODEL_NAME" | tr '/: ' '___')"
+      _cache_dir="${_cache_root}/${_model_slug}"
+      export TLLM_AUTOTUNER_CACHE_PATH="${_cache_dir}/${_cache_base}"
+      mkdir -p "$_cache_dir" 2>/dev/null || true
+      echo "[rank=$RANK] Autotuner cache path: $TLLM_AUTOTUNER_CACHE_PATH"
+      _my_file=$(ls "${_cache_dir}/${_cache_base}".rank${RANK}.json 2>/dev/null | head -n1 || true)
+      if [ -n "$_my_file" ]; then
+        echo "[rank=$RANK] Autotuner cache hit: $(basename "$_my_file")"
+      else
+        _donor=$(ls "${_cache_dir}/${_cache_base}".rank*.json 2>/dev/null | head -n1 || true)
+        if [ -n "$_donor" ]; then
+          _target="${_cache_dir}/${_cache_base}.rank${RANK}.json"
+          cp -n "$_donor" "$_target" 2>/dev/null \
+            && echo "[rank=$RANK] Autotuner cache seeded: $(basename "$_donor") -> $(basename "$_target")" \
+            || echo "[rank=$RANK] Autotuner cache seed failed (continuing)"
+        else
+          echo "[rank=$RANK] Autotuner cache empty; will tune from scratch"
+        fi
+      fi
+    fi
+
     echo "[rank=$RANK/$WORLD_SIZE local=$LOCAL_RANK] Starting ${WORKER_ROLE} worker"
     echo "  Model (HF ID): ${HF_MODEL_ID}"
     echo "  Model (local): ${LOCAL_MODEL_DIR}"

--- a/examples/inferenceX/aks/helm/inferencex/values-gb300-base.yaml
+++ b/examples/inferenceX/aks/helm/inferencex/values-gb300-base.yaml
@@ -73,6 +73,17 @@ trtllmEnv:
   decode: {}
 
 # --------------------------------------------------------------------------
+# TRT-LLM autotuner cache — see README §3.1 for design and rationale.
+# Disable with enabled=false (falls back to re-tuning on every pod start).
+# --------------------------------------------------------------------------
+autotunerCache:
+  enabled: true
+  hostPath: /mnt/nvme/autotuner-cache
+  mountPath: /autotuner-cache
+  # TRT-LLM appends .rank{N}.json to this stem (strips any extension).
+  baseName: inferencex
+
+# --------------------------------------------------------------------------
 # DRA (Dynamic Resource Allocation) — MNNVL ComputeDomain on GB300
 # --------------------------------------------------------------------------
 dra:
@@ -133,7 +144,7 @@ modelDistribution:
     # download/upload, MI auth). When false, every cold node downloads
     # straight from HuggingFace (slower; HF rate limits apply).
     enabled: false
-    storageAccount: "" # e.g. mygb300models
+    account: ""
     container: "" # e.g. models
     # Kubelet user-assigned MI client ID; the MI must have role
     # "Storage Blob Data Contributor" on the storage account above.
@@ -141,6 +152,7 @@ modelDistribution:
     #   az aks show -g <RG> -n <CLUSTER> \
     #     --query identityProfile.kubeletidentity.clientId -o tsv
     # or directly from any GPU node label (AKS sets this automatically):
+    #
     #   kubectl get nodes -l agentpool=gb300 \
     #     -o jsonpath='{.items[0].metadata.labels.kubernetes\.azure\.com/kubelet-identity-client-id}'
     clientId: ""

--- a/examples/inferenceX/aks/run-suite.sh
+++ b/examples/inferenceX/aks/run-suite.sh
@@ -9,10 +9,12 @@
 #   ctx10-gen1-dep16  : conc-666
 #   ctx10-gen1-dep8   : conc-2253
 #
-# Inside a group, recipes share the deployment via -s (skip-deploy). The last
-# recipe of each group passes -t to teardown the whole chart (workloads + infra)
-# so the next group starts with a fresh frontend/etcd/NATS — required to avoid
-# stale Dynamo router state that inflates prefill TTFT (see README §3.1).
+# Every recipe gets a fresh deploy + full teardown (-t). We deliberately do NOT
+# share deployments within a topology group via -s, because TRT-LLM's autotuner
+# warms only one input-shape bucket at deploy time and shape-bucketed cache
+# misses on subsequent recipes inflate prefill TTFT 2-4x (see README §3.1
+# "Reuse scope — same recipe only"). The autotuner cache on /mnt/nvme persists
+# across the teardown, so within-recipe pod restarts still benefit.
 set -u
 cd "$(dirname "$0")"
 LOG_DIR=suite-logs-$(date -u +%Y%m%dT%H%M%SZ)
@@ -20,13 +22,10 @@ mkdir -p "$LOG_DIR"
 SUMMARY="$LOG_DIR/summary.tsv"
 printf 'recipe\tstatus\texit\tstart_utc\tend_utc\tlog\n' > "$SUMMARY"
 
-# test-config :: run-test.sh-flags
-# - first recipe of each topology group has no -s (fresh deploy)
-# - last recipe of each topology group has -t (full teardown for next group)
 TESTS=(
-  "tests/trtllm/gb300-fp4/8k1k/mtp/conc-5.yaml|"
-  "tests/trtllm/gb300-fp4/8k1k/mtp/conc-12.yaml|-s"
-  "tests/trtllm/gb300-fp4/8k1k/mtp/conc-24.yaml|-s -t"
+  "tests/trtllm/gb300-fp4/8k1k/mtp/conc-5.yaml|-t"
+  "tests/trtllm/gb300-fp4/8k1k/mtp/conc-12.yaml|-t"
+  "tests/trtllm/gb300-fp4/8k1k/mtp/conc-24.yaml|-t"
   "tests/trtllm/gb300-fp4/8k1k/mtp/conc-33.yaml|-t"
   "tests/trtllm/gb300-fp4/8k1k/mtp/conc-180.yaml|-t"
   "tests/trtllm/gb300-fp4/8k1k/mtp/conc-308.yaml|-t"

--- a/examples/inferenceX/aks/run-suite.sh
+++ b/examples/inferenceX/aks/run-suite.sh
@@ -20,39 +20,39 @@ cd "$(dirname "$0")"
 LOG_DIR=suite-logs-$(date -u +%Y%m%dT%H%M%SZ)
 mkdir -p "$LOG_DIR"
 SUMMARY="$LOG_DIR/summary.tsv"
-printf 'recipe\tstatus\texit\tstart_utc\tend_utc\tlog\n' > "$SUMMARY"
+printf 'recipe\tstatus\texit\tstart_utc\tend_utc\tlog\n' >"$SUMMARY"
 
 TESTS=(
-  "tests/trtllm/gb300-fp4/8k1k/mtp/conc-5.yaml|-t"
-  "tests/trtllm/gb300-fp4/8k1k/mtp/conc-12.yaml|-t"
-  "tests/trtllm/gb300-fp4/8k1k/mtp/conc-24.yaml|-t"
-  "tests/trtllm/gb300-fp4/8k1k/mtp/conc-33.yaml|-t"
-  "tests/trtllm/gb300-fp4/8k1k/mtp/conc-180.yaml|-t"
-  "tests/trtllm/gb300-fp4/8k1k/mtp/conc-308.yaml|-t"
-  "tests/trtllm/gb300-fp4/8k1k/mtp/conc-666.yaml|-t"
-  "tests/trtllm/gb300-fp4/8k1k/mtp/conc-2253.yaml|-t"
+	"tests/trtllm/gb300-fp4/8k1k/mtp/conc-5.yaml|-t"
+	"tests/trtllm/gb300-fp4/8k1k/mtp/conc-12.yaml|-t"
+	"tests/trtllm/gb300-fp4/8k1k/mtp/conc-24.yaml|-t"
+	"tests/trtllm/gb300-fp4/8k1k/mtp/conc-33.yaml|-t"
+	"tests/trtllm/gb300-fp4/8k1k/mtp/conc-180.yaml|-t"
+	"tests/trtllm/gb300-fp4/8k1k/mtp/conc-308.yaml|-t"
+	"tests/trtllm/gb300-fp4/8k1k/mtp/conc-666.yaml|-t"
+	"tests/trtllm/gb300-fp4/8k1k/mtp/conc-2253.yaml|-t"
 )
 
 for entry in "${TESTS[@]}"; do
-  cfg="${entry%%|*}"
-  flags="${entry##*|}"
-  name=$(basename "$cfg" .yaml)
-  log="$LOG_DIR/$name.log"
-  start=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-  echo "=== $(date -u +%H:%M:%S) START $name flags=[$flags] -> $log ==="
-  if [ -n "$flags" ]; then
-    ./run-test.sh "$cfg" $flags > "$log" 2>&1
-  else
-    ./run-test.sh "$cfg" > "$log" 2>&1
-  fi
-  rc=$?
-  end=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-  verdict=$(grep -oE '(PASS|FAIL|GAP)' "$log" | tail -1 || echo '?')
-  printf '%s\t%s\t%d\t%s\t%s\t%s\n' "$name" "${verdict:-?}" "$rc" "$start" "$end" "$log" >> "$SUMMARY"
-  echo "=== $(date -u +%H:%M:%S) END   $name rc=$rc verdict=${verdict:-?} ==="
-  if [ $rc -ne 0 ]; then
-    echo "!!! $name exited non-zero (rc=$rc); continuing with next recipe"
-  fi
+	cfg="${entry%%|*}"
+	flags="${entry##*|}"
+	name=$(basename "$cfg" .yaml)
+	log="$LOG_DIR/$name.log"
+	start=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+	echo "=== $(date -u +%H:%M:%S) START $name flags=[$flags] -> $log ==="
+	if [ -n "$flags" ]; then
+		./run-test.sh "$cfg" $flags >"$log" 2>&1
+	else
+		./run-test.sh "$cfg" >"$log" 2>&1
+	fi
+	rc=$?
+	end=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+	verdict=$(grep -oE '(PASS|FAIL|GAP)' "$log" | tail -1 || echo '?')
+	printf '%s\t%s\t%d\t%s\t%s\t%s\n' "$name" "${verdict:-?}" "$rc" "$start" "$end" "$log" >>"$SUMMARY"
+	echo "=== $(date -u +%H:%M:%S) END   $name rc=$rc verdict=${verdict:-?} ==="
+	if [ $rc -ne 0 ]; then
+		echo "!!! $name exited non-zero (rc=$rc); continuing with next recipe"
+	fi
 done
 
 echo

--- a/examples/inferenceX/aks/run-suite.sh
+++ b/examples/inferenceX/aks/run-suite.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Driver for full 8-recipe InferenceX suite on a fresh cluster.
+#
+# Topology groups (each group shares one helm values file):
+#   ctx1-gen4         : conc-5, conc-12, conc-24
+#   ctx1-gen3         : conc-33
+#   ctx4-gen1-dep32   : conc-180
+#   ctx8-gen1-dep32   : conc-308
+#   ctx10-gen1-dep16  : conc-666
+#   ctx10-gen1-dep8   : conc-2253
+#
+# Inside a group, recipes share the deployment via -s (skip-deploy). The last
+# recipe of each group passes -t to teardown the whole chart (workloads + infra)
+# so the next group starts with a fresh frontend/etcd/NATS — required to avoid
+# stale Dynamo router state that inflates prefill TTFT (see README §3.1).
+set -u
+cd "$(dirname "$0")"
+LOG_DIR=suite-logs-$(date -u +%Y%m%dT%H%M%SZ)
+mkdir -p "$LOG_DIR"
+SUMMARY="$LOG_DIR/summary.tsv"
+printf 'recipe\tstatus\texit\tstart_utc\tend_utc\tlog\n' > "$SUMMARY"
+
+# test-config :: run-test.sh-flags
+# - first recipe of each topology group has no -s (fresh deploy)
+# - last recipe of each topology group has -t (full teardown for next group)
+TESTS=(
+  "tests/trtllm/gb300-fp4/8k1k/mtp/conc-5.yaml|"
+  "tests/trtllm/gb300-fp4/8k1k/mtp/conc-12.yaml|-s"
+  "tests/trtllm/gb300-fp4/8k1k/mtp/conc-24.yaml|-s -t"
+  "tests/trtllm/gb300-fp4/8k1k/mtp/conc-33.yaml|-t"
+  "tests/trtllm/gb300-fp4/8k1k/mtp/conc-180.yaml|-t"
+  "tests/trtllm/gb300-fp4/8k1k/mtp/conc-308.yaml|-t"
+  "tests/trtllm/gb300-fp4/8k1k/mtp/conc-666.yaml|-t"
+  "tests/trtllm/gb300-fp4/8k1k/mtp/conc-2253.yaml|-t"
+)
+
+for entry in "${TESTS[@]}"; do
+  cfg="${entry%%|*}"
+  flags="${entry##*|}"
+  name=$(basename "$cfg" .yaml)
+  log="$LOG_DIR/$name.log"
+  start=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  echo "=== $(date -u +%H:%M:%S) START $name flags=[$flags] -> $log ==="
+  if [ -n "$flags" ]; then
+    ./run-test.sh "$cfg" $flags > "$log" 2>&1
+  else
+    ./run-test.sh "$cfg" > "$log" 2>&1
+  fi
+  rc=$?
+  end=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  verdict=$(grep -oE '(PASS|FAIL|GAP)' "$log" | tail -1 || echo '?')
+  printf '%s\t%s\t%d\t%s\t%s\t%s\n' "$name" "${verdict:-?}" "$rc" "$start" "$end" "$log" >> "$SUMMARY"
+  echo "=== $(date -u +%H:%M:%S) END   $name rc=$rc verdict=${verdict:-?} ==="
+  if [ $rc -ne 0 ]; then
+    echo "!!! $name exited non-zero (rc=$rc); continuing with next recipe"
+  fi
+done
+
+echo
+echo "===== SUITE SUMMARY ====="
+column -t -s $'\t' "$SUMMARY"

--- a/examples/inferenceX/aks/run-test.sh
+++ b/examples/inferenceX/aks/run-test.sh
@@ -26,6 +26,7 @@ TEARDOWN=false
 SKIP_DEPLOY=false
 DRY_RUN=false
 SKIP_STATS=false
+NO_AUTOTUNER_CACHE=false
 POLL_INTERVAL=30
 TIMESTAMP=$(date -u +%Y%m%dT%H%M%SZ)
 
@@ -42,6 +43,11 @@ Options:
                  after benchmark. Required between recipes that change topology
                  to avoid stale Dynamo router state inflating prefill latency.
   -s             Skip deploy (assume chart already running with correct config)
+  -A             Disable TRT-LLM autotuner cache for this deploy
+                 (--set autotunerCache.enabled=false). Forces a cold
+                 ~2.5 min autotune on every worker; use when the cache on
+                 disk may be stale (e.g. after a TRT-LLM image upgrade or
+                 between recipes if you don't trust shape-bucket reuse).
   -d             Dry run — print commands without executing
   -S             Skip Prometheus stats + plots collection at end
   -h             Show this help
@@ -80,11 +86,12 @@ shift
 	exit 1
 }
 
-while getopts "n:tsdSh" opt; do
+while getopts "n:tsAdSh" opt; do
 	case $opt in
 	n) NAMESPACE="$OPTARG" ;;
 	t) TEARDOWN=true ;;
 	s) SKIP_DEPLOY=true ;;
+	A) NO_AUTOTUNER_CACHE=true ;;
 	d) DRY_RUN=true ;;
 	S) SKIP_STATS=true ;;
 	h) usage ;;
@@ -282,10 +289,16 @@ deploy_chart() {
 	if $DRY_RUN; then
 		echo "[DRY RUN] helm template + kubectl apply with ${base_path} + ${values_path}"
 	else
+		local extra_set=()
+		if $NO_AUTOTUNER_CACHE; then
+			extra_set+=(--set autotunerCache.enabled=false)
+			echo ">>> Autotuner cache disabled for this deploy (-A)"
+		fi
 		helm template inferencex "$HELM_DIR" \
 			--namespace "$NAMESPACE" \
 			-f "$base_path" \
-			-f "$values_path" |
+			-f "$values_path" \
+			"${extra_set[@]}" |
 			kubectl apply -n "$NAMESPACE" -f -
 	fi
 }

--- a/examples/inferenceX/aks/run-test.sh
+++ b/examples/inferenceX/aks/run-test.sh
@@ -38,7 +38,9 @@ Usage: run-test.sh <test-config> [OPTIONS]
 
 Options:
   -n NAMESPACE   Kubernetes namespace (default: inferencex)
-  -t             Teardown helm release after benchmark
+  -t             Teardown chart (workloads + infra: frontend/etcd/NATS/configmaps)
+                 after benchmark. Required between recipes that change topology
+                 to avoid stale Dynamo router state inflating prefill latency.
   -s             Skip deploy (assume chart already running with correct config)
   -d             Dry run — print commands without executing
   -S             Skip Prometheus stats + plots collection at end
@@ -727,10 +729,13 @@ EOF
 }
 
 teardown_chart() {
-	echo ">>> Tearing down..."
+	echo ">>> Tearing down (full: workloads + infra)..."
 	run_cmd kubectl delete mpijobs --all -n "$NAMESPACE" 2>/dev/null || true
 	run_cmd kubectl delete computedomain inferencex -n "$NAMESPACE" 2>/dev/null || true
 	run_cmd kubectl delete resourceclaims --all -n "$NAMESPACE" 2>/dev/null || true
+	run_cmd kubectl delete deployment,statefulset,daemonset,configmap,service,secret \
+		-l app.kubernetes.io/instance=inferencex \
+		-n "$NAMESPACE" 2>/dev/null || true
 }
 
 LOCAL_DIR="${RESULTS_DIR}/${NAME}_${TIMESTAMP}"


### PR DESCRIPTION
## Summary

Follow-up improvements to the InferenceX AKS chart merged in #128. Six commits covering a blob-cache detection fix, a TRT-LLM autotuner cache (with per-model scoping and rank-agnostic seeding), a multi-recipe suite driver with full chart teardown, and supporting docs.

All changes scoped to `examples/inferenceX/aks/`. No changes to other parts of the repo.

## Commits

| SHA | Description |
|---|---|
| `57071cf` | **fix**: blob-cache detection — list blob root before deciding HF vs azcopy; add distribute-model timing markers for Grafana correlation |
| `d8e298a` | **feat**: TRT-LLM autotuner cache (`autotunerCache.enabled: true` by default). Per-model subdirectory under `/mnt/nvme/autotuner-cache/<model>/` (prevents cross-model collision); rank-agnostic seeding inside `worker-entrypoint.sh` (a sibling rank's cache is copied if the local rank file is missing — autotuner key is shape-based, not rank-based, so this is safe). Cuts cold-start ~2.5 min → ~1 s on warm restart of the same recipe. |
| `62bf5d3` | **fix**: `run-test.sh -t` now does a *full* chart teardown (workloads + frontend Deployment, etcd/NATS StatefulSets, ConfigMaps, Services, Secrets selected via `app.kubernetes.io/instance=inferencex`). Adds `run-suite.sh` driver to walk all 8 recipes end-to-end. Fixes stale-Dynamo-router-state TTFT inflation observed when reusing a long-lived deployment across recipes. |
| `747091d` | **docs**: explain the autotuner cache cross-recipe limitation (TRT-LLM autotuner key is *bucketed input shape*, see `tensorrt_llm/_torch/autotuner.py:442-461`; mixing concurrencies against the same deployment misses cache and inflates TTFT 2–4×). Re-validation table (cold vs warm conc-33: 49 s saved, identical 1607 tok/s/GPU). `run-suite.sh` updated to use `-t` for every recipe. |
| `401c9f0` | **feat**: `-A` flag on `run-test.sh` to disable the autotuner cache for a single deploy (sets `autotunerCache.enabled=false` via `helm template --set`). |
| `a13afe0` | **docs**: README §7 `-A` example; clarify `run-suite.sh` uses `-t` between every recipe (not just topology groups); note that `-t` preserves `/mnt/nvme/autotuner-cache/<model>/` so warm autotune still applies on same-recipe re-deploy. |

## Validation

- 8-recipe suite executed end-to-end via `run-suite.sh`. Teardown fix verified — fresh-deploy recipes (e.g. conc-33 with `-t`) **PASS at 100.6%** of InferenceX reference where they had previously failed via `-s` reuse (TTFT inflation root-caused to autotuner shape-bucket misses).
- Cold vs warm autotuner re-validation (conc-33, same recipe): cold WAIT_READY→WORKERS_READY 8m58s → warm 8m9s, **49 s saved (13%)**, throughput identical (1607.2 vs 1606.9 tok/s/GPU). Modest top-level delta because parallel startup costs dominate critical path; sub-phase delta is much larger.
- `-A` flag verified via `helm template` diff: `TLLM_AUTOTUNER_CACHE_PATH` env emissions, hostPath volume, and `mpirun -x` forwarding all drop out; bash prelude in `worker-entrypoint.sh` short-circuits because the env var is unset.
- TRT-LLM autotuner cache-key composition verified against upstream source (commit `62ce575`).
